### PR TITLE
Fix stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,16 @@ cpan[n]> install File::Path
 If you do not have installation privileges on your machine, you might want to use local::lib.
 <http://jjnapiorkowski.typepad.com/modern-perl/2010/02/bootstrapping-locallib.html> describes a one-step-solution how to do it; the necessary script can be found at <https://github.com/jjn1056/bootstrap-locallib.pl>
 
-## Usage
+## Quick start
+
+If you do not need to fine-tune your data and just want to get out a GTFS file from your DIVA data you can use the `all.sh` script.
+To run it just pass in the path to your diva data and the name of your agency:
+
+	./all.sh ~/documents/diva/myAgency myAgency
+
+After some computation times you can find your data as GTFS-file in the folder ./build/gtfs/myAgency and ./build/gtfs/myAgency.zip.
+
+## Detailed Usage
 
 ### Step 1: Setting up the databases
 
@@ -74,7 +83,7 @@ Please provide loaddiva with all stop definition (`haltestellen.\*` but _not_ `h
 All three scripts will go through the DIVA tables and transform their content into GTFS format.
 Agencies can be filled with additional information using the parameter "set":
 
-	.agencies2gtfs.pl --set agency_url="http://www.meinVerkehrsbetrieb.de" --set agency_phone=00491234567
+	./agencies2gtfs.pl --set agency_url="http://www.meinVerkehrsbetrieb.de" --set agency_phone=00491234567
 
 For the coordinate transformation, `cs2cs` from `proj(1)` is needed. Currently, only a subset of coordinate reference systems (specified in the column `plan` in the DIVA tables) will be converted.
 Support for other CRS (e.g. GIP1) still needs to be implemented... sometimes... by someone (pull requests are appreciated).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you do not have installation privileges on your machine, you might want to us
 
 ### Step 1: Setting up the databases
 
-initdb will take care of setting up the sqlite databases.   
+initdb will take care of setting up the sqlite databases.
 Just run `./initdb.pl --create all` to create both DIVA and GTFS databases: `build/data/divadata.db` and `build/data/diva2gtfs.db`
 
 	Usage: ./initdb command <options>
@@ -66,11 +66,17 @@ Please provide loaddiva with all stop definition (`haltestellen.\*` but _not_ `h
 
 ### Step 3: Convert DIVA tables to GTFS
 
+	./agencies2gtfs.pl
 	./stops2gtfs.pl
 	./service2gtfs.pl
 
 
-Both scripts will go through the DIVA tables and transform their content into GTFS format. For the coordinate transformation, `cs2cs` from `proj(1)` is needed. Currently, only a subset of coordinate reference systems (specified in the column `plan` in the DIVA tables) will be converted.
+All three scripts will go through the DIVA tables and transform their content into GTFS format.
+Agencies can be filled with additional information using the parameter "set":
+
+	.agencies2gtfs.pl --set agency_url="http://www.meinVerkehrsbetrieb.de" --set agency_phone=00491234567
+
+For the coordinate transformation, `cs2cs` from `proj(1)` is needed. Currently, only a subset of coordinate reference systems (specified in the column `plan` in the DIVA tables) will be converted.
 Support for other CRS (e.g. GIP1) still needs to be implemented... sometimes... by someone (pull requests are appreciated).
 
 ### Step 4: Load route files

--- a/agencies2gtfs.pl
+++ b/agencies2gtfs.pl
@@ -5,22 +5,22 @@ use warnings;
 use utf8;
 use DBI;
 use File::Path qw(make_path);
+use Getopt::Long;
 use Text::ParseWords;
-use open ':encoding(windows-1252)';
 
 # take care of windows newlines
 #$/ = "\n";
 
-my $agency_timezone = "Europe/Berlin";
-my $agency_lang = "de";
-my $agency_url = "http://www.ding.eu";
+# Hard-coded values
+my %defaults = (
+	agency_fare_url => undef,
+	agency_lang => "de",
+	agency_phone => undef,
+	agency_timezone => "Europe/Berlin",
+	agency_url => "http://www.example.com/"
+);
 
-my $line;
-
-# DEFINE I/O FILES
-my $log;
-my $log_folder = "build/log";
-make_path($log_folder);
+GetOptions ("set=s" => \%defaults) or die("Error in command line arguments\n");
 
 # --------------------
 # CONNECT TO DATABASE
@@ -29,11 +29,22 @@ make_path($log_folder);
 my $db_folder = "build/data";
 make_path($db_folder);
 
-my $driver   = "SQLite";
-my $database = "$db_folder/diva2gtfs.db";
-my $dsn = "DBI:$driver:dbname=$database";
+my $driver = "SQLite";
+my $divadatabase = "$db_folder/divadata.db";
+my $divadsn = "DBI:$driver:dbname=$divadatabase";
 my $userid = "";
 my $password = "";
+my $divadbh = DBI->connect($divadsn, $userid, $password, { RaiseError => 1 })
+                      or die $DBI::errstr;
+
+# sacrificing security for speed
+$divadbh->{AutoCommit} = 0;
+$divadbh->do( "COMMIT; PRAGMA synchronous=OFF; BEGIN TRANSACTION" );
+
+print "Opened diva-database successfully\n";
+
+my $database = "$db_folder/diva2gtfs.db";
+my $dsn = "DBI:$driver:dbname=$database";
 my $dbh = DBI->connect($dsn, $userid, $password, { RaiseError => 1 })
                       or die $DBI::errstr;
 
@@ -41,58 +52,60 @@ my $dbh = DBI->connect($dsn, $userid, $password, { RaiseError => 1 })
 $dbh->{AutoCommit} = 0;
 $dbh->do( "COMMIT; PRAGMA synchronous=OFF; BEGIN TRANSACTION" );
 
-print "Opened database successfully\n";
+print "Opened gtfs-database successfully\n";
 
 # --------------------------
 # END OF DATABASE GEDOENS
 # --------------------------
 
-open ($log, ">","$log_folder/agencies2gtfs.log") or die "Something terrible happened while opening my log file: $!";
-#open ($log, ">","/dev/null") or die "Something terrible happened while opening my log file: $!";
-
-# ------------------------------------------
-# ITERATE OVER ALL FILES PASSED AS ARGUMENTS
-
-foreach my $file (@ARGV) {
-	process($file);
-}
 
 # -------------------------------------------
+# MAIN METHOD
+#--------------------------------------------
 
+my $agency_id;
+my $agency_name;
+my $agency_url;
+my $agency_timezone;
+my $agency_lang;
+my $agency_phone;
+my $agency_fare_url;
 
-# ------------------------------------------
-# PROCESS EACH FILE
-# -----------------------------------------
+print "Agencies ";
 
-sub process {
-	my $arg = shift;
-	open (FILE, "<", "$arg") or die("Could not open inputfile: $!");
-	print $log "Now working on $arg\n";
+my $sth = $divadbh->prepare('SELECT bzw AS agency_id, bzwtext AS agency_name FROM OpBranch');
+$sth->execute();
 
-	foreach $line (<FILE>) {
-		chomp $line;
-		if ($line =~ /rec;.*?;\"(?<agency_id>.*?)\";\"(?<agency_name>.*?)\";/) {
-			print "parsing: $+{agency_id},$+{agency_name}\n";
-			my $sth = $dbh->prepare('INSERT INTO agency values (?, ?, ?, ?, ?, ?, ?)');
-			$sth->execute($+{agency_id},$+{agency_name},$agency_url,$agency_timezone,$agency_lang, undef, undef);
-		}
-	}
+print "queried...";
 
-	$dbh->commit;
+while (my $row = $sth->fetchrow_hashref()) {
+	$agency_id = $row->{agency_id};
+	$agency_name = $row->{agency_name};
+	$agency_url = $defaults{agency_url};
+	$agency_timezone = $defaults{agency_timezone};
+	$agency_lang = $defaults{agency_lang};
+	$agency_phone = $defaults{agency_phone};
+	$agency_fare_url = $defaults{agency_fare_url};
 
-	close FILE;
+	my $sthDelete = $dbh->prepare('DELETE FROM agency WHERE agency_id = ?');
+	$sthDelete->execute($agency_id);
+
+	my $sthInsert = $dbh->prepare('INSERT INTO agency VALUES (?, ?, ?, NULLIF(?, \'\'), NULLIF(?, \'\'), NULLIF(?, \'\'), NULLIF(?, \'\'))');
+	$sthInsert->execute($agency_id, $agency_name, $agency_url, $agency_timezone, $agency_lang, $agency_phone, $agency_fare_url);
 }
 
-# ---------------------------------
-# END OF FILE PROCESSING SUBROUTINE
-# ---------------------------------
+print " and written to GTFS database\n";
 
+$dbh->commit;
+$divadbh->commit;
 
 # ---------------------------------
 # CLEANING UP!
 # ---------------------------------
 
-close $log;
+$divadbh->disconnect();
+print "Diva-Database closed. ";
+
 $dbh->disconnect();
-print "Database closed. ";
+print "GTFS-Database closed. ";
 print "Everything done. Bye!\n";

--- a/agencies2gtfs.pl
+++ b/agencies2gtfs.pl
@@ -75,9 +75,9 @@ print "Agencies ";
 
 my $sth = $divadbh->prepare('SELECT bzw AS agency_id, bzwtext AS agency_name FROM OpBranch');
 $sth->execute();
-
 print "queried...";
 
+my $sthInsert = $dbh->prepare('INSERT OR REPLACE INTO agency VALUES (?, ?, ?, NULLIF(?, \'\'), NULLIF(?, \'\'), NULLIF(?, \'\'), NULLIF(?, \'\'))');
 while (my $row = $sth->fetchrow_hashref()) {
 	$agency_id = $row->{agency_id};
 	$agency_name = $row->{agency_name};
@@ -87,25 +87,19 @@ while (my $row = $sth->fetchrow_hashref()) {
 	$agency_phone = $defaults{agency_phone};
 	$agency_fare_url = $defaults{agency_fare_url};
 
-	my $sthDelete = $dbh->prepare('DELETE FROM agency WHERE agency_id = ?');
-	$sthDelete->execute($agency_id);
-
-	my $sthInsert = $dbh->prepare('INSERT INTO agency VALUES (?, ?, ?, NULLIF(?, \'\'), NULLIF(?, \'\'), NULLIF(?, \'\'), NULLIF(?, \'\'))');
 	$sthInsert->execute($agency_id, $agency_name, $agency_url, $agency_timezone, $agency_lang, $agency_phone, $agency_fare_url);
 }
-
+$dbh->commit();
 print " and written to GTFS database\n";
-
-$dbh->commit;
-$divadbh->commit;
 
 # ---------------------------------
 # CLEANING UP!
 # ---------------------------------
 
 $divadbh->disconnect();
-print "Diva-Database closed. ";
+print "Diva-Database closed.\n";
 
 $dbh->disconnect();
-print "GTFS-Database closed. ";
-print "Everything done. Bye!\n";
+print "GTFS-Database closed.\n";
+print "Everything done.\n";
+print "Bye!\n";

--- a/all.sh
+++ b/all.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Check preconditions
+#####################
+
+if [[ $# -eq 1 ]]; then
+    AGENCY_NAME=$(basename "${1}")
+elif [[ $# -ne 2 ]] ; then
+    printf "%s\n" "Invalid params set!"
+    printf "%s\n" "Usage: ./$(basename "${0}") PATH AGENCY_NAME"
+    exit 0
+fi
+
+# Variable definition
+#####################
+
+DIVA_PATH="${1}"
+if [[ $# -eq 2 ]]; then
+    AGENCY_NAME="${2}"
+fi
+
+FILE_BZW="${DIVA_PATH}/bzw"
+FILE_LNRLIT="${DIVA_PATH}/lin/lnrlit"
+FILES_ANSCHLB="${DIVA_PATH}/anschlb.*"
+FILES_HALTESTELLEN="${DIVA_PATH}/haltestellen*"
+FILES_VBESCH="${DIVA_PATH}/vbesch.*"
+# Perform ~ expansion
+DIVA_PATH="`eval echo ${DIVA_PATH}`"
+# Perform * expansion
+FILES_HALTESTELLEN=(${FILES_HALTESTELLEN[@]})
+
+# Main method
+#####################
+
+printf "%s\n" "Building GTFS for ${AGENCY_NAME} from \"${DIVA_PATH}\""
+printf "\n%s\n\n" "Initializing new databases"
+
+./initdb.pl --clear all
+
+printf "\n%s\n\n" "Loading data into DIVA database"
+
+./loaddiva.pl ${FILES_HALTESTELLEN[@]/*.format32/}
+./loaddiva.pl ${FILES_VBESCH}
+./loaddiva.pl ${FILE_BZW}
+./loaddiva.pl ${FILES_ANSCHLB}
+./loaddiva.pl ${FILE_LNRLIT}
+
+printf "\n%s\n\n" "Transforming DIVA to GTFS"
+
+./agencies2gtfs.pl
+./stops2gtfs.pl
+./service2gtfs.pl
+./diva2gtfs.pl --path "${DIVA_PATH}/"
+./transfers2gtfs.pl
+
+printf "\n%s\n\n" "Exporting GTFS files"
+
+./export.sh "${AGENCY_NAME}"

--- a/efaShapeExporter.pl
+++ b/efaShapeExporter.pl
@@ -246,7 +246,7 @@ sub shape_request {
 				my $shapesth = $dbh->prepare('INSERT INTO shapes (shape_id, shape_pt_lat, shape_pt_lon, shape_pt_sequence) VALUES (?,?,?,?)');
 				$shapesth->execute($Trips{$shapetrip}{shape_id},$latitude,$longitude,$sequence);
 			}
-		$sequence++;
+			$sequence++;
 		}
 		$dbh->commit();
 	}
@@ -277,5 +277,7 @@ sub dbconnect {
 
 sub dbdisconnect {
 	$dbh->disconnect();
-	print "Disconnected. Bye.\n";
+	print "Database closed. ";
+	print "Everything done.\n";
+	print "Bye!\n";
 }

--- a/export.sh
+++ b/export.sh
@@ -2,8 +2,9 @@
 
 # Check preconditions
 
-if [[ $# -eq 0 ]] ; then
-    echo 'No output agency specified!'
+if [[ $# -ne 1 ]] ; then
+    printf "%s\n" "Invalid params set!"
+    printf "%s\n" "Usage: ./$(basename "${0}") AGENCY_NAME"
     exit 0
 fi
 
@@ -14,17 +15,18 @@ OUTPUT_DIR="${OUTPUT_BASE}/${AGENCY_NAME}"
 
 ## Main
 
+rm -rf "${OUTPUT_DIR}"
 mkdir -p "${OUTPUT_DIR}"
 
 # Create GTFS file contents from database (into .txt files)
 
-sqlite3 -header -csv "${DB_NAME}" "select * from stops AS s where s.stop_id in (select distinct parent_station from stops AS st where location_type = 0 and st.stop_id in (select distinct stop_id from stop_times)) UNION select * from stops where stop_id in (select distinct stop_id from stop_times);" > "${OUTPUT_DIR}/stops.txt"
-sqlite3 -header -csv "${DB_NAME}" "select * from calendar where service_id in (select distinct service_id from trips);" > "${OUTPUT_DIR}/calendar.txt"
-sqlite3 -header -csv "${DB_NAME}" "select * from calendar_dates where service_id in (select distinct service_id from trips);" > "${OUTPUT_DIR}/calendar_dates.txt"
-sqlite3 -header -csv "${DB_NAME}" "select route_id, service_id, trip_id, trip_headsign, direction_id, block_id from trips;" > "${OUTPUT_DIR}/trips.txt"
-sqlite3 -header -csv "${DB_NAME}" "select * from routes;" > "${OUTPUT_DIR}/routes.txt"
-sqlite3 -header -csv "${DB_NAME}" "select * from stop_times;" > "${OUTPUT_DIR}/stop_times.txt"
-sqlite3 -header -csv "${DB_NAME}" "select * from agency;" > "${OUTPUT_DIR}/agency.txt"
+sqlite3 -header -csv "${DB_NAME}" "SELECT * FROM stops AS s WHERE s.stop_id IN (SELECT DISTINCT parent_station FROM stops AS st WHERE location_type = 0 AND st.stop_id in (SELECT DISTINCT stop_id FROM stop_times)) UNION SELECT * FROM stops WHERE stop_id in (SELECT DISTINCT stop_id FROM stop_times);" > "${OUTPUT_DIR}/stops.txt"
+sqlite3 -header -csv "${DB_NAME}" "SELECT * FROM calendar WHERE service_id in (SELECT DISTINCT service_id FROM trips);" > "${OUTPUT_DIR}/calendar.txt"
+sqlite3 -header -csv "${DB_NAME}" "SELECT * FROM calendar_dates WHERE service_id in (SELECT DISTINCT service_id FROM trips);" > "${OUTPUT_DIR}/calendar_dates.txt"
+sqlite3 -header -csv "${DB_NAME}" "SELECT route_id, service_id, trip_id, trip_headsign, direction_id, block_id FROM trips;" > "${OUTPUT_DIR}/trips.txt"
+sqlite3 -header -csv "${DB_NAME}" "SELECT * FROM routes WHERE route_type IS NOT NULL;" > "${OUTPUT_DIR}/routes.txt"
+sqlite3 -header -csv "${DB_NAME}" "SELECT * FROM stop_times;" > "${OUTPUT_DIR}/stop_times.txt"
+sqlite3 -header -csv "${DB_NAME}" "SELECT * FROM agency;" > "${OUTPUT_DIR}/agency.txt"
 
 # Create single GTFS archive file from .txt files
 

--- a/initdb.pl
+++ b/initdb.pl
@@ -8,17 +8,16 @@ use Getopt::Long;
 
 dbconnect();
 
-GetOptions	(	"drop=s"		=>	\&drophandler,
-							"create=s"	=>	\&createhandler,
-							"clear=s"		=>	\&clearhandler,
-						)
-						or die("Error in command line arguments\n");
+GetOptions	(
+	"drop=s"	=>	\&drophandler,
+	"create=s"	=>	\&createhandler,
+	"clear=s"	=>	\&clearhandler,
+) or die("Error in command line arguments\n");
 
 my $dbh;
 my $divadbh;
 
 disconnect();
-
 
 sub drophandler {
 	my ($opt_name, $opt_value) = @_;
@@ -395,6 +394,11 @@ sub cleardiva {
 
 sub disconnect {
 	$dbh->disconnect();
+	print "GTFS-Database closed.\n";
+
 	$divadbh->disconnect();
-	print "Disconnected. Bye.\n";
+	print "Diva-Database closed.\n";
+
+	print "Everything done.\n";
+	print "Bye!\n";
 }

--- a/loaddiva.pl
+++ b/loaddiva.pl
@@ -94,7 +94,7 @@ sub process {
 
 	}
 
-	$divadbh->commit;
+	$divadbh->commit();
 
 	close FILE;
 }
@@ -110,4 +110,5 @@ sub process {
 
 $divadbh->disconnect();
 print "Database closed. ";
-print "Everything done. Bye!\n";
+print "Everything done.\n";
+print "Bye!\n";

--- a/service2gtfs.pl
+++ b/service2gtfs.pl
@@ -9,7 +9,9 @@ use File::Path qw(make_path);
 
 my $dbh;
 my $divadbh;
-my $Strf = "%Y%m%d";
+my $tf_dt = "%Y%m%d";
+my $tf_sprintf = "%04d%02d%02d";
+my $tz = DateTime::TimeZone->new( name => 'floating' );
 
 dbconnect();
 
@@ -26,6 +28,9 @@ while (my $rowCnt = $sth->fetchrow_hashref()) {
 $sth = $divadbh->prepare('SELECT anfjahr, code, dat_von, dat_bis, vbt_von, vbt_bis, vt FROM ServiceRestriction');
 $sth->execute();
 
+my $sthCalendarInsert = $dbh->prepare('INSERT OR REPLACE INTO calendar (service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday, start_date, end_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+my $sthCalendarDateInsert = $dbh->prepare('INSERT OR REPLACE INTO calendar_dates (service_id, date, exception_type) VALUES (?, ?, ?)');
+
 my $date_from = undef;
 my $date_to = undef;
 my $i = 0;
@@ -35,15 +40,15 @@ while (my $row = $sth->fetchrow_hashref()) {
 		year       => $row->{anfjahr},
 		month      => 1,
 		day        => 1,
-		time_zone  => "floating",
+		time_zone  => $tz,
 	);
 	$referencedate->truncate(to => 'day');
 
 	# clone starting date and add start and end months to get start and end date
 	my $workingdate = $referencedate->clone();
-	$workingdate->add( months => $row->{vbt_von} );
+	$workingdate->add(months => $row->{vbt_von});
 	my $enddate = $referencedate->clone();
-	$enddate->add ( months => $row->{vbt_bis} );
+	$enddate->add(months => $row->{vbt_bis});
 
 	if (! defined $date_from  || $date_from > $workingdate) {
 		$date_from = $workingdate->clone();
@@ -52,86 +57,104 @@ while (my $row = $sth->fetchrow_hashref()) {
 		$date_to = $enddate->clone();
 	}
 
-	print ("$i/$cnt: $row->{code}, $referencedate, von: ", $workingdate->strftime($Strf) , ", bis: ",$enddate->strftime($Strf),"\n");
-
-	my $sth = $dbh->prepare('INSERT OR REPLACE INTO calendar (service_id, monday, tuesday, wednesday, thursday, friday, saturday, sunday, start_date, end_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
-	$sth->execute($row->{code}, 0, 0, 0, 0, 0, 0, 0, $workingdate->strftime($Strf), $enddate->strftime($Strf));
-	$dbh->commit();
+	print ("$i/$cnt: $row->{code}, $referencedate, von: ", $workingdate->strftime($tf_dt) , ", bis: ", $enddate->strftime($tf_dt), "\n");
+	$sthCalendarInsert->execute($row->{code}, 0, 0, 0, 0, 0, 0, 0, $workingdate->strftime($tf_dt), $enddate->strftime($tf_dt));
 
 	my @vt = $row->{vt} =~ /[0-9A-Fa-f]{8}/g;
-
 	foreach my $vtmonth (@vt) {
-		my %job = ('code' => $row->{code}, 'month' => $workingdate, 'daypattern' => $vtmonth);
-		eval_month(%job);
-		$workingdate->add( months => '1' );
+		my %job = (
+			code => $row->{code},
+			month => $workingdate,
+			pattern => $vtmonth
+		);
+
+		insert_calendardates4month(%job);
+
+		$workingdate->add(months => 1);
 	}
 
 	$dbh->commit();
 }
 
 $sth = $dbh->prepare('INSERT OR REPLACE INTO calendar VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
-$sth->execute(0, 1, 1, 1, 1, 1, 0, 0, $date_from->strftime($Strf), $date_to->strftime($Strf));
-$sth->execute(2, 0, 0, 0, 0, 0, 1, 0, $date_from->strftime($Strf), $date_to->strftime($Strf));
-$sth->execute(3, 0, 0, 0, 0, 0, 0, 1, $date_from->strftime($Strf), $date_to->strftime($Strf));
+$sth->execute(0, 1, 1, 1, 1, 1, 0, 0, $date_from->strftime($tf_dt), $date_to->strftime($tf_dt));
+$sth->execute(2, 0, 0, 0, 0, 0, 1, 0, $date_from->strftime($tf_dt), $date_to->strftime($tf_dt));
+$sth->execute(3, 0, 0, 0, 0, 0, 0, 1, $date_from->strftime($tf_dt), $date_to->strftime($tf_dt));
 $dbh->commit();
 
 disconnect();
 
-sub eval_month{
+sub insert_calendardates4month {
 	my %process = @_;
 
-	# create list of dates for current month
-	my $enddate = DateTime->last_day_of_month( year => $process{month}->year(), month => $process{month}->month() );
-
 	# convert hexadeximal month pattern into binary and put it into an array. Each day becomes one array cell with 0 or 1
-	my @is_valid = (map { unpack ('B*', pack ('H*',$_)) } $process{daypattern})[0] =~ /[01]/g;
+	my @is_valid = (map { unpack ('B*', pack ('H*', $_)) } $process{pattern})[0] =~ /[01]/g;
 
+	my $month = $process{month}->month();
+	my $year = $process{month}->year();
+	# create list of dates for current month
+	my $enddate = DateTime->last_day_of_month(
+		month => $month,
+		year => $year
+	);
+
+	my $last_day = $enddate->day();
 	# iterate over all dates of the current month
-	my $sth = $dbh->prepare('INSERT OR REPLACE INTO calendar_dates (service_id, date, exception_type) VALUES (?, ?, ?)');
-	for (my $date = $process{month}->clone; $date <= $enddate; $date->add( days => 1 )) {
-		my $day = $date->day();
+	for (my $day = 1; $day <= $last_day; ++$day) {
 		# consider only days where this service_id is valid
-		if ($is_valid[32-$day]) {
-#			print ("$process{code}, $year$month$day, $is_valid[32-$day]\n");
-			$sth->execute($process{code}, $date->strftime($Strf), $is_valid[32-$day]);
+		if ($is_valid[32 - $day]) {
+			my $time = sprintf $tf_sprintf, $year, $month, $day;
+#			print ("$process{code}, $time, $is_valid[32 - $day]\n");
+			$sthCalendarDateInsert->execute($process{code}, $time, $is_valid[32 - $day]);
 		}
 	}
 
-	$dbh->commit();
+#   This would do the same as the loop above, but with strict DateTime usage (which is more flexibel when it comes to date formatting, but far slower)
+#	for (my $date = $process{month}->clone; $date <= $enddate; $date->add( days => 1 )) {
+#		my $day = $date->day();
+#		# consider only days where this service_id is valid
+#		if ($is_valid[32-$day]) {
+#			my time = $date->strftime($tf_dt);
+#			print ("$process{code}, $time, $is_valid[32 - $day]\n");
+#			$sthCalendarDateInsert->execute($process{code}, time, $is_valid[32 - $day]);
+#		}
+#	}
 }
 
-# _----------------------
-# TAKE CARE OF HOLIDAYS
-# -----------------------
-
+# Takes care of the holiday
 sub insert_holidays {
 	# get hold of all holidays in Germany and special holidays in Baden-Wuerttemberg
 	my $holidays_ref = holidays(
 		WHERE=>['common', 'bw']
 	);
+
 	my @holidays = @$holidays_ref;
+	my $tz = DateTime::TimeZone->new( name => 'Europe/Berlin' );
 	print "Holidays for Germany and BaWue loaded!\n";
 	foreach my $holiday (@holidays) {
-		my $holiday_date = DateTime->from_epoch( epoch => $holiday, time_zone => 'Europe/Berlin' );
+		my $holiday_date = DateTime->from_epoch(
+			epoch => $holiday,
+			time_zone => $tz
+		);
 		$holiday_date->truncate( to => 'day' );
 		my $day_of_week = $holiday_date->day_of_week();
 
 		# monday through friday: Disable Mo-Fr service, enable sunday service
 		if ($day_of_week < 6) {
-			print ("Disabling 0, enabling 3 for ", $holiday_date->strftime($Strf), "\n");
+			print ("Disabling 0, enabling 3 for ", $holiday_date->strftime($tf_dt), "\n");
 			my $sth = $dbh->prepare('INSERT OR REPLACE INTO calendar_dates (service_id, date, exception_type) VALUES (?, ?, ?)');
-			$sth->execute(0,$holiday_date->strftime($Strf),2);
+			$sth->execute(0,$holiday_date->strftime($tf_dt),2);
 			$sth = $dbh->prepare('INSERT OR REPLACE INTO calendar_dates (service_id, date, exception_type) VALUES (?, ?, ?)');
-			$sth->execute(3,$holiday_date->strftime($Strf),1);
+			$sth->execute(3,$holiday_date->strftime($tf_dt),1);
 
 		}
 		# saturday: disable sa service, enable sunday service
 		elsif ($day_of_week == 6) {
-			print ("Disabling 2, enabling 3 for ", $holiday_date->strftime($Strf), "\n");
+			print ("Disabling 2, enabling 3 for ", $holiday_date->strftime($tf_dt), "\n");
 			my $sth = $dbh->prepare('INSERT OR REPLACE INTO calendar_dates (service_id, date, exception_type) VALUES (?, ?, ?)');
-			$sth->execute(2,$holiday_date->strftime($Strf),2);
+			$sth->execute(2,$holiday_date->strftime($tf_dt),2);
 			$sth = $dbh->prepare('INSERT OR REPLACE INTO calendar_dates (service_id, date, exception_type) VALUES (?, ?, ?)');
-			$sth->execute(3,$holiday_date->strftime($Strf),1);
+			$sth->execute(3,$holiday_date->strftime($tf_dt),1);
 		}
 	}
 }

--- a/stops2gtfs.pl
+++ b/stops2gtfs.pl
@@ -135,7 +135,7 @@ while (my $row = $sth->fetchrow_hashref()) {
 	$insertsth->execute($stop_id,undef,$stop_name,$stop_lat,$stop_lon,$zone_id,"1",undef,undef);
 }
 
-print "...and written to GTFS database\n";
+print " and written to GTFS database\n";
 
 # Child station handling
 
@@ -174,7 +174,7 @@ while (my $row = $sth->fetchrow_hashref()) {
 
 }
 
-print("...and written to GTFS database\n");
+print(" and written to GTFS database\n");
 
 # Station handling without child stations
 
@@ -208,7 +208,7 @@ while (my $row = $sth->fetchrow_hashref()) {
 	$insertsth->execute($row->{stop_id},undef,$row->{stop_name},$stop_lat,$stop_lon,$row->{zone_id},"0",undef,undef);
 }
 
-print "...and written to GTFS database\n";
+print " and written to GTFS database\n";
 
 # Station handling without coordinates
 

--- a/stops2gtfs.pl
+++ b/stops2gtfs.pl
@@ -59,7 +59,8 @@ my %crs = (
 # GIP1 causes issues when calling cs2cs (exception cause is "projection not named")
 #	GIP1 => {
 #		cs2cs_params => '+init=epsg:31259 +to +init:epsg:4326',
-#		offset => 6000000
+##		offset => 6000000
+#		offset => 987402
 #	},
 	MVTT => {
 		cs2cs_params => '+init=epsg:31466 +to +init=epsg:4326',
@@ -94,6 +95,7 @@ my %crs = (
 		offset => 1000000
 	}
 );
+my @supported_crs = keys %crs;
 my $stop_id = "";
 my $stop_name = "";
 my $stop_lat = "";
@@ -104,18 +106,20 @@ my $zone_id = "";
 
 print "Parent stations ";
 
-my $sth = $divadbh->prepare('SELECT S.hstnr AS stop_id, S.hstname AS stop_name, group_concat(tz.tzonen,"") AS zone_id, HK.x AS stop_lat, HK.y AS stop_lon, HK.plan AS plan FROM Stop AS S
-LEFT OUTER JOIN Stop_hst_koord as HK ON S._AutoKey_=HK._FK__AutoKey_
-LEFT OUTER JOIN Stop_tzonen as tz ON S._AutoKey_=tz._FK__AutoKey_
-WHERE S._AutoKey_ IN (SELECT SHS._FK__AutoKey_ FROM Stop_hst_steig AS SHS)
-GROUP BY stop_id, HK.x');
+my $insertsth = $dbh->prepare('INSERT OR REPLACE INTO stops VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+my $sth = $divadbh->prepare('SELECT S.hstnr AS stop_id, S.hstname AS stop_name, bzn.hstohne AS stop_name_bzn, group_concat(tz.tzonen, "") AS zone_id, HK.x AS stop_lat, HK.y AS stop_lon, HK.plan AS plan FROM Stop AS S
+LEFT OUTER JOIN Stop_bzn AS bzn ON S._AutoKey_ = bzn._FK__AutoKey_
+LEFT OUTER JOIN Stop_hst_koord as HK ON S._AutoKey_ = HK._FK__AutoKey_
+LEFT OUTER JOIN Stop_tzonen as tz ON S._AutoKey_ = tz._FK__AutoKey_
+WHERE S._AutoKey_ IN (SELECT SHS._FK__AutoKey_ FROM Stop_hst_steig AS SHS) AND HK.plan IN (\'' . join('\', \'',  @supported_crs) . '\')
+GROUP BY stop_id');
 $sth->execute();
-
 print "queried...";
 
 while (my $row = $sth->fetchrow_hashref()) {
 	$stop_id = $row->{stop_id};
-	if (defined $row->{stop_name}) { $stop_name = $row->{stop_name}; }
+	if (defined $row->{stop_name} and $row->{stop_name} ne "") { $stop_name = $row->{stop_name}; }
+	elsif (defined $row->{stop_name_bzn}) { $stop_name = $row->{stop_name_bzn}; }
 	if (defined $row->{zone_id}) { $zone_id = $row->{zone_id}; }
 	if (defined $row->{plan} and exists $crs{$row->{plan}} and defined $row->{stop_lat} and defined $row->{stop_lon}) {
 		$stop_lat = $row->{stop_lat};
@@ -131,29 +135,29 @@ while (my $row = $sth->fetchrow_hashref()) {
 		$stop_lat = undef;
 	}
 
-	my $insertsth = $dbh->prepare('INSERT OR REPLACE INTO stops VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
-	$insertsth->execute($stop_id,undef,$stop_name,$stop_lat,$stop_lon,$zone_id,"1",undef,undef);
+	$insertsth->execute($stop_id, undef, $stop_name, $stop_lat, $stop_lon, $zone_id, "1", undef, undef);
 }
-
+$dbh->commit();
 print " and written to GTFS database\n";
 
 # Child station handling
 
 print "Child stations";
 
-$sth = $divadbh->prepare('SELECT S.hstnr AS stop_id, S.hstname AS stop_name, group_concat(tz.tzonen,"") as zone_id, SHS.steig AS steig, SPK.x AS stop_lat, SPK.y AS stop_lon, SPK.plan AS plan FROM Stop AS S
-LEFT OUTER JOIN Stop_tzonen as tz ON S._AutoKey_=tz._FK__AutoKey_
+$sth = $divadbh->prepare('SELECT S.hstnr AS stop_id, S.hstname AS stop_name, bzn.hstohne AS stop_name_bzn, group_concat(tz.tzonen, "") as zone_id, SHS.steig AS steig, SPK.x AS stop_lat, SPK.y AS stop_lon, SPK.plan AS plan FROM Stop AS S
+LEFT OUTER JOIN Stop_bzn AS bzn ON S._AutoKey_ = bzn._FK__AutoKey_
+LEFT OUTER JOIN Stop_tzonen as tz ON S._AutoKey_ = tz._FK__AutoKey_
 LEFT OUTER JOIN Stop_hst_steig AS SHS on S._AutoKey_ = SHS._FK__AutoKey_
 LEFT OUTER JOIN StopPlatformKoord AS SPK ON SHS._AutoKey_ = SPK._FK__AutoKey_
-WHERE SHS.steig NOT LIKE "Eing%"
-GROUP BY stop_id, steig, SPK.x');
+WHERE SHS.steig NOT LIKE "Eing%" AND SPK.plan IN (\'' . join('\', \'',  @supported_crs) . '\')
+GROUP BY stop_id, steig');
 $sth->execute();
-
 print(" queried...");
 
 while (my $row = $sth->fetchrow_hashref()) {
 	$stop_id = $row->{stop_id} . $row->{steig};
-	if (defined $row->{stop_name}) { $stop_name = $row->{stop_name}; }
+	if (defined $row->{stop_name} and $row->{stop_name} ne "") { $stop_name = $row->{stop_name}; }
+	elsif (defined $row->{stop_name_bzn}) { $stop_name = $row->{stop_name_bzn}; }
 	if (defined $row->{zone_id}) { $zone_id = $row->{zone_id}; }
 	if (defined $row->{plan} and exists $crs{$row->{plan}} and defined $row->{stop_lat} and defined $row->{stop_lon}) {
 		$stop_lat = $row->{stop_lat};
@@ -169,27 +173,29 @@ while (my $row = $sth->fetchrow_hashref()) {
 		$stop_lat = undef;
 	}
 
-	my $insertsth = $dbh->prepare('INSERT OR REPLACE INTO stops VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
-	$insertsth->execute($stop_id,undef,$stop_name,$stop_lat,$stop_lon,$zone_id,"0",$row->{stop_id},undef);
-
+	$insertsth->execute($stop_id, undef, $stop_name, $stop_lat, $stop_lon, $zone_id, "0", $row->{stop_id}, undef);
 }
-
+$dbh->commit();
 print(" and written to GTFS database\n");
 
 # Station handling without child stations
 
 print "Stations without child stations";
 
-$sth = $divadbh->prepare('SELECT S.hstnr AS stop_id, S.hstname AS stop_name, group_concat(tz.tzonen,"") as zone_id, HK.x AS stop_lat, HK.y AS stop_lon, HK.plan AS plan FROM Stop AS S
-LEFT OUTER JOIN Stop_tzonen as tz ON S._AutoKey_=tz._FK__AutoKey_
+$sth = $divadbh->prepare('SELECT S.hstnr AS stop_id, S.hstname AS stop_name, bzn.hstohne AS stop_name_bzn, group_concat(tz.tzonen, "") as zone_id, HK.x AS stop_lat, HK.y AS stop_lon, HK.plan AS plan FROM Stop AS S
+LEFT OUTER JOIN Stop_bzn AS bzn ON S._AutoKey_ = bzn._FK__AutoKey_
 LEFT OUTER JOIN Stop_hst_koord as HK ON S._AutoKey_=HK._FK__AutoKey_
-WHERE S._AutoKey_ NOT IN (SELECT SHS._FK__AutoKey_ FROM Stop_hst_steig AS SHS)
-GROUP BY stop_id, HK.x');
+LEFT OUTER JOIN Stop_tzonen as tz ON S._AutoKey_=tz._FK__AutoKey_
+WHERE S._AutoKey_ NOT IN (SELECT SHS._FK__AutoKey_ FROM Stop_hst_steig AS SHS) AND HK.plan IN (\'' . join('\', \'',  @supported_crs) . '\')
+GROUP BY stop_id');
 $sth->execute();
-
 print " queried...";
 
 while (my $row = $sth->fetchrow_hashref()) {
+	$stop_id = $row->{stop_id};
+	if (defined $row->{stop_name} and $row->{stop_name} ne "") { $stop_name = $row->{stop_name}; }
+	elsif (defined $row->{stop_name_bzn}) { $stop_name = $row->{stop_name_bzn}; }
+	if (defined $row->{zone_id}) { $zone_id = $row->{zone_id}; }
 	if (defined $row->{plan} and exists $crs{$row->{plan}} and defined $row->{stop_lat} and defined $row->{stop_lon}) {
 		$stop_lat = $row->{stop_lat};
 		$stop_lon = -1 * ($row->{stop_lon} - $crs{$row->{plan}}{offset});
@@ -204,10 +210,9 @@ while (my $row = $sth->fetchrow_hashref()) {
 		$stop_lat = undef;
 	}
 
-	my $insertsth = $dbh->prepare('INSERT OR REPLACE INTO stops VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
-	$insertsth->execute($row->{stop_id},undef,$row->{stop_name},$stop_lat,$stop_lon,$row->{zone_id},"0",undef,undef);
+	$insertsth->execute($stop_id, undef, $stop_name, $stop_lat, $stop_lon, $zone_id, "0", undef, undef);
 }
-
+$dbh->commit();
 print " and written to GTFS database\n";
 
 # Station handling without coordinates
@@ -226,19 +231,20 @@ print " and written to GTFS database\n";
 #	}
 
 #	my $insertsth = $dbh->prepare('INSERT INTO stops VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
-#	$insertsth->execute($stop_id,undef,$stop_name,undef,undef,undef,"0",undef,undef);
+#	$insertsth->execute($stop_id, undef, $stop_name, undef, undef, undef, "0", undef, undef);
 #}
 
-$dbh->commit;
-$divadbh->commit;
+$dbh->commit();
+$divadbh->commit();
 
 # ---------------------------------
 # CLEANING UP!
 # ---------------------------------
 
 $divadbh->disconnect();
-print "Diva-Database closed. ";
+print "Diva-Database closed.\n";
 
 $dbh->disconnect();
-print "GTFS-Database closed. ";
-print "Everything done. Bye!\n";
+print "GTFS-Database closed.\n";
+print "Everything done.\n";
+print "Bye!\n";

--- a/transfers2gtfs.pl
+++ b/transfers2gtfs.pl
@@ -11,23 +11,21 @@ my $divadbh;
 my $Strf = "%Y%m%d";
 
 dbconnect();
-
 findtransfers();
-
 disconnect();
 
-# We will look for transfers between trips now. Transfers can have two types in both DIVA
-# and GTFS: a) transfers where you can stay in the same vehicle (sitz_blb=Y or y in DIVA, which is
-# „Sitzenbleiben“, or „just stay seated for transferring“), and b) transfers where you have
-# to change your vehicle at a certain stop (sitz_blb=N in DIVA).
+# We will look for transfers between trips now.
+# Transfers can have two types in both DIVA and GTFS:
+#   a) transfers where you can stay in the same vehicle (sitz_blb=Y or y in DIVA, which is „Sitzenbleiben“, or „just stay seated for transferring“), and
+#   b) transfers where you have to change your vehicle at a certain stop (sitz_blb=N in DIVA).
 
 sub findtransfers {
+	my $sth = $divadbh->prepare('SELECT hst_nr_an, linie_erg_an, richt_an, wttyp_an, zeit_von_an, zeit_bis_an, hst_nr_ab, linie_erg_ab, richt_ab, wttyp_ab, zeit_von_ab, zeit_bis_ab, sitz_blb
+	FROM TransferProtection');
 
-	my $sth = $divadbh->prepare('SELECT hst_nr_an, linie_erg_an, richt_an, wttyp_an, zeit_von_an, zeit_bis_an, hst_nr_ab, linie_erg_ab, richt_ab, wttyp_ab, zeit_von_ab, zeit_bis_ab, sitz_blb FROM TransferProtection');
 	$sth->execute();
 
 	while (my $row = $sth->fetchrow_hashref()) {
-
 		# In DIVA, the time frames are calculated in seconds from midnight. I introduced a little
 		# subroutine to convert those seconds into a hh:mm:ss string
 		my $from_starttime = secondstogtfstime($row->{zeit_von_an});
@@ -124,84 +122,86 @@ sub findtransfers {
 	}
 }
 
-
 #  / \ WARNING WARNING WARNING WARNING WARNING
 # / ! \ The following code is a complete and utter mess. It is slow as hell and in dire need of better SQL requests
 # -----  WARNING WARNING WARNING WARNING WARNING
 # TODO FIXME
 
 sub messyblockhandler {
-		my %messyparams = @_;
+	my %messyparams = @_;
 
-		print ("Transfer from $messyparams{starttrip} to $messyparams{endtrip} at $messyparams{from_stop} to $messyparams{to_stop} from $messyparams{from_starttime}, $messyparams{from_endtime} to $messyparams{to_starttime}, $messyparams{to_endtime}, Block: ", $messyparams{block},"\n");
+	print ("Transfer from $messyparams{starttrip} to $messyparams{endtrip} at $messyparams{from_stop} to $messyparams{to_stop} from $messyparams{from_starttime}, $messyparams{from_endtime} to $messyparams{to_starttime}, $messyparams{to_endtime}, Block: ", $messyparams{block},"\n");
 
-		my $sth = $dbh->prepare('select trips.trip_id AS trip_id, arrival_time, stop_id, block_id, service_id from trips join stop_times on trips.trip_id = stop_times.trip_id where trips.trip_id like ? ESCAPE "\" and arrival_time >= ? and arrival_time <= ? and stop_id LIKE ?');
-		$sth->execute($messyparams{starttrip}, $messyparams{from_starttime},$messyparams{from_endtime}, $messyparams{from_stop}."%");
+	my $sth = $dbh->prepare('SELECT trips.trip_id AS trip_id, arrival_time, stop_id, block_id, service_id
+	FROM trips
+	JOIN stop_times on trips.trip_id = stop_times.trip_id
+	WHERE trips.trip_id like ? ESCAPE "\" AND arrival_time >= ? AND arrival_time <= ? AND stop_id LIKE ?');
 
-		my %block_identifier;
-		my %triptransfer;
+	$sth->execute($messyparams{starttrip}, $messyparams{from_starttime}, $messyparams{from_endtime}, $messyparams{from_stop}."%");
 
-		while (my $arrival_triprow = $sth->fetchrow_hashref()) {
+	my %block_identifier;
+	my %triptransfer;
 
-			my $current_arrival_time = $arrival_triprow->{arrival_time};
-			my $current_arrival_trip = $arrival_triprow->{trip_id};
-			my $current_arrival_stop = $arrival_triprow->{stop_id};
+	while (my $arrival_triprow = $sth->fetchrow_hashref()) {
+		my $current_arrival_time = $arrival_triprow->{arrival_time};
+		my $current_arrival_trip = $arrival_triprow->{trip_id};
+		my $current_arrival_stop = $arrival_triprow->{stop_id};
 
-			 # Transfer by staying on the vehicle
-			if ($messyparams{block} eq "Y" or $messyparams{block} eq "y") {
-				# Does the inbound trip already have a block ID? If yes, we'll use that later on!
-				if (defined $arrival_triprow->{block_id}) {
-					$block_identifier{$current_arrival_trip} = $arrival_triprow->{block_id};
-				}
-				# If not, we will just use the current trip as a block identifier
-				else {
-					$block_identifier{$current_arrival_trip} = $current_arrival_trip;
-				}
+		 # Transfer by staying on the vehicle
+		if ($messyparams{block} eq "Y" or $messyparams{block} eq "y") {
+			# Does the inbound trip already have a block ID? If yes, we'll use that later on!
+			if (defined $arrival_triprow->{block_id}) {
+				$block_identifier{$current_arrival_trip} = $arrival_triprow->{block_id};
+			}
+			# If not, we will just use the current trip as a block identifier
+			else {
+				$block_identifier{$current_arrival_trip} = $current_arrival_trip;
+			}
 			print ("trip1: " , $current_arrival_trip, " $current_arrival_time gets " . $block_identifier{$current_arrival_trip});
-			}
-
-			# Let's find matching departure trips for this arrival trip! Look at all
-			# departures between the inbound trip's arrival time and the end of the transfer time frame.
-			# TODO is this better?
-			# TODO select trip_id, min(arrival_time) from stop_times where trip_id like ? ESCAPE "\" and arrival_time >= ? and arrival_time <= ? and stop_id LIKE ?;
-
-			my $sth = $dbh->prepare('SELECT trips.trip_id, arrival_time, stop_id
-			FROM trips
-			JOIN stop_times ON trips.trip_id = stop_times.trip_id
-			WHERE trips.trip_id LIKE ? ESCAPE "\" AND arrival_time >= ? AND arrival_time <= ? AND stop_id LIKE ? AND service_id = ?
-			ORDER BY arrival_time ASC
-			LIMIT 1;');
-
-			$sth->execute($messyparams{endtrip}, $current_arrival_time,$messyparams{to_endtime}, $messyparams{from_stop}."%", $arrival_triprow->{service_id});
-
-			while (my $departure_triprow = $sth->fetchrow_hashref()) {
-				my $current_departure_trip = $departure_triprow->{trip_id};
-				my $current_departure_stop = $departure_triprow->{stop_id};
-
-				# Transfer by staying on the vehicle
-				if (($messyparams{block} eq "Y") or ($messyparams{block} eq "y")) {
-					$block_identifier{$current_departure_trip} = $block_identifier{$current_arrival_trip};
-					print (" trip2: " , $departure_triprow->{trip_id} , ", ", $departure_triprow->{arrival_time} ," gets " . $block_identifier{$current_departure_trip} . "\n");
-				}
-				# Else: Write a transfer
-				elsif ($messyparams{block} eq "N") {
-				my $transfersth = $dbh->prepare('INSERT INTO TRANSFERS (from_stop_id, to_stop_id, transfer_type, from_trip_id, to_trip_id) VALUES (?, ?, ?, ?, ?)');
-				$transfersth->execute($current_arrival_stop, $current_departure_stop, 1, $current_departure_trip, $current_arrival_trip);
-				}
-			}
 		}
 
-		# Finally, if the current request was for block transfers, use the temporary hash
-		# to write everything to the GTFS database!
-		if ($messyparams{block} eq "Y") {
-			for (keys %block_identifier) {
-#			 print "$_: $block_identifier{$_}\n"
-				my $updatesth = $dbh->prepare('UPDATE trips SET block_id = ? WHERE trip_id = ?');
-				$updatesth->execute($block_identifier{$_}, $_);
+		# Let's find matching departure trips for this arrival trip! Look at all
+		# departures between the inbound trip's arrival time and the end of the transfer time frame.
+		# TODO is this better?
+		# TODO select trip_id, min(arrival_time) from stop_times where trip_id like ? ESCAPE "\" and arrival_time >= ? and arrival_time <= ? and stop_id LIKE ?;
+
+		my $sth = $dbh->prepare('SELECT trips.trip_id, arrival_time, stop_id
+		FROM trips
+		JOIN stop_times ON trips.trip_id = stop_times.trip_id
+		WHERE trips.trip_id LIKE ? ESCAPE "\" AND arrival_time >= ? AND arrival_time <= ? AND stop_id LIKE ? AND service_id = ?
+		ORDER BY arrival_time ASC
+		LIMIT 1;');
+
+		$sth->execute($messyparams{endtrip}, $current_arrival_time,$messyparams{to_endtime}, $messyparams{from_stop}."%", $arrival_triprow->{service_id});
+
+		while (my $departure_triprow = $sth->fetchrow_hashref()) {
+			my $current_departure_trip = $departure_triprow->{trip_id};
+			my $current_departure_stop = $departure_triprow->{stop_id};
+
+			# Transfer by staying on the vehicle
+			if (($messyparams{block} eq "Y") or ($messyparams{block} eq "y")) {
+				$block_identifier{$current_departure_trip} = $block_identifier{$current_arrival_trip};
+				print (" trip2: " , $departure_triprow->{trip_id} , ", ", $departure_triprow->{arrival_time} ," gets " . $block_identifier{$current_departure_trip} . "\n");
+			}
+			# Else: Write a transfer
+			elsif ($messyparams{block} eq "N") {
+			my $transfersth = $dbh->prepare('INSERT INTO TRANSFERS (from_stop_id, to_stop_id, transfer_type, from_trip_id, to_trip_id) VALUES (?, ?, ?, ?, ?)');
+			$transfersth->execute($current_arrival_stop, $current_departure_stop, 1, $current_departure_trip, $current_arrival_trip);
 			}
 		}
+	}
 
-		$dbh->commit();
+	# Finally, if the current request was for block transfers, use the temporary hash
+	# to write everything to the GTFS database!
+	if ($messyparams{block} eq "Y") {
+		for (keys %block_identifier) {
+#		 print "$_: $block_identifier{$_}\n"
+			my $updatesth = $dbh->prepare('UPDATE trips SET block_id = ? WHERE trip_id = ?');
+			$updatesth->execute($block_identifier{$_}, $_);
+		}
+	}
+
+	$dbh->commit();
 }
 
 #--------------------------------------------------------------------
@@ -240,9 +240,13 @@ sub dbconnect {
 		                    or die $DBI::errstr;
 }
 
-
 sub disconnect {
 	$dbh->disconnect();
+	print "GTFS-Database closed.\n";
+
 	$divadbh->disconnect();
-	print "Disconnected. Bye.\n";
+	print "Diva-Database closed.\n";
+
+	print "Everything done.\n";
+	print "Bye!\n";
 }


### PR DESCRIPTION
This PR also includes the changes from the last one (fix-agency branch)

It adds handling of leading zeros for stop_ids and also regards the stop_name if it is defined in the stop_bzn diva table.

To some degree it also handles prepared statements a bit better (defining the prepared statement outside of a loop while only replacing values in the loop before executing the query). This should lead to a small performance improvement in general. An other performance improvement was done in service2gtfs.pl where calendar_date handling is about 10 to 20 times faster now - only due to not using DateTime in a critical for-loop.